### PR TITLE
Implement SPORK_14_REQUIRE_SENTINEL

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -113,6 +113,7 @@ bool CSporkManager::IsSporkActive(int nSporkID)
             case SPORK_10_STORMNODE_PAY_UPDATED_NODES:     r = SPORK_10_STORMNODE_PAY_UPDATED_NODES_DEFAULT; break;
             case SPORK_12_RECONSIDER_BLOCKS:                r = SPORK_12_RECONSIDER_BLOCKS_DEFAULT; break;
             case SPORK_13_OLD_SUPERBLOCK_FLAG:              r = SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT; break;
+            case SPORK_14_REQUIRE_SENTINEL_FLAG:            r = SPORK_14_REQUIRE_SENTINEL_FLAG_DEFAULT; break;
             default:
                 LogPrint("spork", "CSporkManager::IsSporkActive -- Unknown Spork ID %d\n", nSporkID);
                 r = 4070908800; // 2099-1-1 i.e. off by default
@@ -138,6 +139,7 @@ int64_t CSporkManager::GetSporkValue(int nSporkID)
         case SPORK_10_STORMNODE_PAY_UPDATED_NODES:     return SPORK_10_STORMNODE_PAY_UPDATED_NODES_DEFAULT;
         case SPORK_12_RECONSIDER_BLOCKS:                return SPORK_12_RECONSIDER_BLOCKS_DEFAULT;
         case SPORK_13_OLD_SUPERBLOCK_FLAG:              return SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT;
+        case SPORK_14_REQUIRE_SENTINEL_FLAG:            return SPORK_14_REQUIRE_SENTINEL_FLAG_DEFAULT;
         default:
             LogPrint("spork", "CSporkManager::GetSporkValue -- Unknown Spork ID %d\n", nSporkID);
             return -1;
@@ -155,6 +157,7 @@ int CSporkManager::GetSporkIDByName(std::string strName)
     if (strName == "SPORK_10_STORMNODE_PAY_UPDATED_NODES")     return SPORK_10_STORMNODE_PAY_UPDATED_NODES;
     if (strName == "SPORK_12_RECONSIDER_BLOCKS")                return SPORK_12_RECONSIDER_BLOCKS;
     if (strName == "SPORK_13_OLD_SUPERBLOCK_FLAG")              return SPORK_13_OLD_SUPERBLOCK_FLAG;
+    if (strName == "SPORK_14_REQUIRE_SENTINEL_FLAG")            return SPORK_14_REQUIRE_SENTINEL_FLAG;
 
     LogPrint("spork", "CSporkManager::GetSporkIDByName -- Unknown Spork name '%s'\n", strName);
     return -1;
@@ -171,6 +174,7 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
         case SPORK_10_STORMNODE_PAY_UPDATED_NODES:     return "SPORK_10_STORMNODE_PAY_UPDATED_NODES";
         case SPORK_12_RECONSIDER_BLOCKS:                return "SPORK_12_RECONSIDER_BLOCKS";
         case SPORK_13_OLD_SUPERBLOCK_FLAG:              return "SPORK_13_OLD_SUPERBLOCK_FLAG";
+        case SPORK_14_REQUIRE_SENTINEL_FLAG:            return "SPORK_14_REQUIRE_SENTINEL_FLAG";
         default:
             LogPrint("spork", "CSporkManager::GetSporkNameByID -- Unknown Spork ID %d\n", nSporkID);
             return "Unknown";

--- a/src/spork.h
+++ b/src/spork.h
@@ -18,7 +18,7 @@ class CSporkManager;
     - This would result in old clients getting confused about which spork is for what
 */
 static const int SPORK_START                                            = 10001;
-static const int SPORK_END                                              = 10012;
+static const int SPORK_END                                              = 10013;
 
 static const int SPORK_2_INSTANTSEND_ENABLED                            = 10001;
 static const int SPORK_3_INSTANTSEND_BLOCK_FILTERING                    = 10002;
@@ -28,6 +28,7 @@ static const int SPORK_9_SUPERBLOCKS_ENABLED                            = 10008;
 static const int SPORK_10_STORMNODE_PAY_UPDATED_NODES                   = 10009;
 static const int SPORK_12_RECONSIDER_BLOCKS                             = 10011;
 static const int SPORK_13_OLD_SUPERBLOCK_FLAG                           = 10012;
+static const int SPORK_14_REQUIRE_SENTINEL_FLAG                         = 10013;
 
 static const int64_t SPORK_2_INSTANTSEND_ENABLED_DEFAULT                = 0;            // ON
 static const int64_t SPORK_3_INSTANTSEND_BLOCK_FILTERING_DEFAULT        = 0;            // ON
@@ -37,6 +38,7 @@ static const int64_t SPORK_9_SUPERBLOCKS_ENABLED_DEFAULT                = 407090
 static const int64_t SPORK_10_STORMNODE_PAY_UPDATED_NODES_DEFAULT       = 4070908800;   // OFF
 static const int64_t SPORK_12_RECONSIDER_BLOCKS_DEFAULT                 = 0;            // 0 BLOCKS
 static const int64_t SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT               = 4070908800;   // OFF
+static const int64_t SPORK_14_REQUIRE_SENTINEL_FLAG_DEFAULT             = 4070908800;   // OFF
 
 extern std::map<uint256, CSporkMessage> mapSporks;
 extern CSporkManager sporkManager;

--- a/src/stormnode-payments.cpp
+++ b/src/stormnode-payments.cpp
@@ -635,7 +635,7 @@ bool CStormnodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::st
         return false;
     }
 
-    int nRank = snodeman.GetStormnodeRank(vinStormnode, nBlockHeight - 101, nMinRequiredProtocol);
+    int nRank = snodeman.GetStormnodeRank(vinStormnode, nBlockHeight - 101, nMinRequiredProtocol, false);
 
     if(nRank > SNPAYMENTS_SIGNATURES_TOTAL) {
         // It's common to have stormnodes mistakenly think they are in the top 10
@@ -665,7 +665,7 @@ bool CStormnodePayments::ProcessBlock(int nBlockHeight)
     // if we have not enough data about stormnodes.
     if(!stormnodeSync.IsStormnodeListSynced()) return false;
 
-    int nRank = snodeman.GetStormnodeRank(activeStormnode.vin, nBlockHeight - 101, GetMinStormnodePaymentsProto());
+    int nRank = snodeman.GetStormnodeRank(activeStormnode.vin, nBlockHeight - 101, GetMinStormnodePaymentsProto(), false);
 
     if (nRank == -1) {
         LogPrint("snpayments", "CStormnodePayments::ProcessBlock -- Unknown Stormnode\n");

--- a/src/stormnode.h
+++ b/src/stormnode.h
@@ -9,6 +9,7 @@
 #include "key.h"
 #include "main.h"
 #include "net.h"
+#include "spork.h"
 #include "timedata.h"
 
 class CStormnode;
@@ -258,6 +259,19 @@ public:
     bool IsPoSeVerified() { return nPoSeBanScore <= -STORMNODE_POSE_BAN_MAX_SCORE; }
 
     bool IsWatchdogExpired() { return nActiveState == STORMNODE_WATCHDOG_EXPIRED; }
+
+   bool IsValidForPayment()
+    {
+        if(nActiveState == STORMNODE_ENABLED) {
+            return true;
+        }
+        if(!sporkManager.IsSporkActive(SPORK_14_REQUIRE_SENTINEL_FLAG) &&
+           (nActiveState == STORMNODE_WATCHDOG_EXPIRED)) {
+            return true;
+        }
+
+        return false;
+    }
 
     bool IsValidNetAddr();
 

--- a/src/stormnodeman.cpp
+++ b/src/stormnodeman.cpp
@@ -477,7 +477,7 @@ CStormnode* CStormnodeMan::GetNextStormnodeInQueueForPayment(int nBlockHeight, b
     BOOST_FOREACH(CStormnode &sn, vStormnodes)
     {
         sn.Check();
-        if(!sn.IsEnabled()) continue;
+        if(!sn.IsValidForPayment()) continue;
 
         // //check protocol version
         if(sn.nProtocolVersion < snpayments.GetMinStormnodePaymentsProto()) continue;
@@ -583,9 +583,12 @@ int CStormnodeMan::GetStormnodeRank(const CTxIn& vin, int nBlockHeight, int nMin
     // scan for winner
     BOOST_FOREACH(CStormnode& sn, vStormnodes) {
         if(sn.nProtocolVersion < nMinProtocol) continue;
+        sn.Check();
         if(fOnlyActive) {
-            sn.Check();
             if(!sn.IsEnabled()) continue;
+        }
+        else {
+            if(!sn.IsValidForPayment()) continue;
         }
         int64_t nScore = sn.CalculateScore(blockHash).GetCompact(false);
 


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
This creates a new spork: SPORK_14_REQUIRE_SENTINEL which controls whether WATCHDOG_EXPIRED nodes are paid or not.

This spork is being used by Dash 12.0 migration to 12.1 instead of requiring masternode payment enforcement to be turned off for the entire migration.