### PR TITLE
[Qt] Fix stormnode tab. Default to enabled

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -85,7 +85,7 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("theme", "");
 
     if (!settings.contains("fShowStormnodesTab"))
-        settings.setValue("fShowStormnodesTab", stormnodeConfig.getCount());
+        settings.setValue("fShowStormnodesTab", true);
 
     if (!settings.contains("fShowAdvancedPSUI"))
         settings.setValue("fShowAdvancedPSUI", false);


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Fixes the problem where you can see the stormnode tab by default but it doesn't work until you enable it in the options menu.
#### Was this PR tested and how? (If testing is not needed, please explain why)
Yes, with a new DarkSilk-Qt.conf file on Ubuntu 16.04 64-bit.
#### Does this PR resolve an open issue (reference issue #)?
No. this issue didn't get added to the issue list yet.

