### PR TITLE
fix excessive banning, remove some redundant logic

### DIFF
--- a/src/stormnode.h
+++ b/src/stormnode.h
@@ -79,7 +79,7 @@ public:
 
     bool Sign(CKey& keyStormnode, CPubKey& pubKeyStormnode);
     bool CheckSignature(CPubKey& pubKeyStormnode, int &nDos);
-    bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fSimpleCheck = false);
+    bool CheckAndUpdate(int& nDos, bool fSimpleCheck = false);
     void Relay();
 
     CStormnodePing& operator=(CStormnodePing from)

--- a/src/stormnodeman.cpp
+++ b/src/stormnodeman.cpp
@@ -124,9 +124,6 @@ bool CStormnodeMan::Add(CStormnode &sn)
 {
     LOCK(cs);
 
-    if (!sn.IsEnabled() && !sn.IsPreEnabled())
-        return false;
-
     CStormnode *psn = Find(sn.vin);
     if (psn == NULL) {
         LogPrint("stormnode", "CStormnodeMan::Add -- Adding new Stormnode: addr=%s, %i now\n", sn.addr.ToString(), size() + 1);
@@ -734,7 +731,7 @@ void CStormnodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
         LogPrint("stormnode", "SNPING -- Stormnode ping, stormnode=%s new\n", snp.vin.prevout.ToStringShort());
 
         int nDos = 0;
-        if(snp.CheckAndUpdate(nDos, false)) return;
+        if(snp.CheckAndUpdate(nDos)) return;
 
         if(nDos > 0) {
             // if anything significant failed, mark that node


### PR DESCRIPTION
* Since we send all snb's now regardless of sn state, ping check for sigTime being too old is obsolete (and wrong).
Also removing fRequireEnabled, this logic is deprecated too it seems.

* remove (pre-)enabled check in CStormnodeMan::Add
