### PR TITLE
Backport btc pr7907

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -575,17 +575,26 @@ public:
         int nFound = 0;
         if (b.empty())
             return nFound;
-        iterator pc = begin();
+        CScript result;
+        iterator pc = begin(), pc2 = begin();
         opcodetype opcode;
         do
         {
-            while (end() - pc >= (long)b.size() && memcmp(&pc[0], &b[0], b.size()) == 0)
+            result.insert(result.end(), pc2, pc);
+            while (static_cast<size_t>(end() - pc) >= b.size() && std::equal(b.begin(), b.end(), pc))
             {
-                pc = erase(pc, pc + b.size());
+                pc = pc + b.size();
                 ++nFound;
             }
+            pc2 = pc;
         }
         while (GetOp(pc, opcode));
+
+        if (nFound > 0) {
+            result.insert(result.end(), pc2, end());
+            *this = result;
+        }
+
         return nFound;
     }
     int Find(opcodetype op) const


### PR DESCRIPTION
Fixing this https://bitslog.wordpress.com/2017/01/08/a-bitcoin-transaction-that-takes-5-hours-to-verify/

* Unit test for CScript::FindAndDelete

* Replace memcmp with std::equal in CScript::FindAndDelete

Function is stl; std::equal just makes more sense.

* Replace c-style cast with c++ style static_cast.

* Improve worst-case behavior of CScript::FindAndDelete

Thanks to Sergio Lerner for identifying this issue and suggesting this kind of solution.

<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?

#### Was this PR tested and how? (If testing is not needed, please explain why)

#### Does this PR resolve an open issue (reference issue #)?
