### PR TITLE
[Debugger] Fix Qt project file used for debugger UI

### DIFF
--- a/darksilk-qt.pro
+++ b/darksilk-qt.pro
@@ -604,7 +604,6 @@ SOURCES += \
     src/utiltime.cpp \
     src/validationinterface.cpp \
     src/versionbits.cpp \
-    src/compat/strnlen.cpp \
     src/qt/paymentrequest.pb.cc \
     src/dns/dns.cpp \
     src/dns/dslkdns.cpp \


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Remove strnlen.cpp from Qt project file 
#### Was this PR tested and how? (If testing is not needed, please explain why)
Yes, using Ubuntu 16.04.  The project file will not work on Windows and likely not on OSX.
#### Does this PR resolve an open issue (reference issue #)?
No, just keeps the Qt project file functional.